### PR TITLE
Memory Leak

### DIFF
--- a/background.js
+++ b/background.js
@@ -97,7 +97,8 @@ function updateUser(nickname,timeout) {
 	if (need_update || user.solutions === undefined && !user.solutions_pending) {
 		user.solutions_pending = true;
 		saveDB();
-		getURL('https://toster.ru/user/'+nickname+'/questions',(text)=>{
+		getURL('https://toster.ru/user/'+nickname+'/questions',(text1)=>{
+			let text = JSON.parse(JSON.stringify(text1));
 			delete user.solutions_pending;
 			//solutions
 			let r = /\s*(\d+)\s*<\/div>/g; //todo: very very bad, need better algorytm!
@@ -165,23 +166,25 @@ function analyzeQuestion(question_id, now) {
 	let q = {is_pending:true, ut:now};
 	db.question[question_id] = q;
 	saveDB();
-	getURL('https://toster.ru/q/' + question_id, function(text) {
+	getURL('https://toster.ru/q/' + question_id, function(text1) {
+		let text = JSON.parse(JSON.stringify(text1));
+
 		//get title
 		const index_title_str = '<h1 class="question__title" itemprop="name ">';
 		let index_title = text.indexOf(index_title_str);
 		if (index_title > -1) {
 			let index_title2 = text.indexOf("</h1>\n",index_title);
 			let txt = text.substring(index_title + index_title_str.length + 1, index_title2).trim();
-			if (txt) q.t = txt; //title!
+			if (txt) q.t = JSON.parse(JSON.stringify(txt)); //title!
 		}
 		//get user name
 		let index_name = text.indexOf('<meta itemprop="name" content="');
 		if (index_name > -1) {
 			let index_name2 = text.indexOf('</span>', index_name);
 			let txt = text.substr(index_name, index_name2 - index_name);
-			let user_name = txt.match(/<meta itemprop=\"name\" content=\"([^"]*)\">/)[1];
+			let user_name = JSON.parse(JSON.stringify(txt)).match(/<meta itemprop=\"name\" content=\"([^"]*)\">/)[1];
 			//console.log('user_name',user_name);
-			let user_nickname = txt.match(/<meta itemprop=\"alternateName\" content=\"([^"]*)\">/)[1];
+			let user_nickname = JSON.parse(JSON.stringify(txt)).match(/<meta itemprop=\"alternateName\" content=\"([^"]*)\">/)[1];
 			//console.log('user_nickname',user_nickname);
 			if (user_nickname) {
 				delete q.is_pending;
@@ -198,7 +201,7 @@ function analyzeQuestion(question_id, now) {
 		if (index_tags > -1) {
 			let index_tags2 = text.indexOf('</ul>', index_tags || 0);
 			let txt = text.substr(index_tags, index_tags2 - index_tags);
-			q.tags = parseTags(txt);
+			q.tags = parseTags(JSON.parse(JSON.stringify(txt)));
 		}
 		//check subscribtions
 		if (text.indexOf('"btn btn_subscribe btn_active"') > -1) q.sb = 1;


### PR DESCRIPTION
Небольшой грязный трюк чтобы отвязаться от использования ответов ajax по ссылке.

Heap перестало скакать, стало нормально себя вести в целом.

JavaScript Memory столбец, вообще почти не растет теперь, хотя до этого в небо прыгал от одной прогрузки любой страницы со списком вопросом.
![image](https://user-images.githubusercontent.com/1709666/56621269-8f4c8500-6634-11e9-81bd-f2cc8034042f.png)

Общее потребление памяти всё равно растёт иногда почему-то, не знаю так же сильно или нет как до этого, по идее должны быть медленнее. Тем не менее растет не из-за JS уже, потому что столбец JS Memory показывает минимальные значения.

Думаю в коде есть еще места где можно отвязаться таким же образом от жирных данных.
Я искал через Heap Snapshot.
Самый смак там как раз были ссылки на всю загруженную html страницу вопроса/юзера по всем ajax запросам которые были сделаны за время работы. И там-то и засветилась привязка html => sliced string.
Так что можно покапать еще там.